### PR TITLE
Work with dynamic Wasp file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This will perform initial part of migrating your Wasp project from 0.11 to 0.12,
 
 Run `npm run bundle` to build the code and then run the `./dist/index.js` from the parent directory of the Wasp project you want to test it on.
 
-You can additionaly set `WASP_MIGRATE_DEV` env var to tell it to use `wasp-cli` instead of `wasp` bin.
+You can additionally set `WASP_MIGRATE_DEV`` env var to tell it to use `wasp-cli` instead of `wasp` bin.
 
 Example (where `websockets-realtime-voting` is a Wasp app inside `wasp/examples/` dir):
 ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This will perform initial part of migrating your Wasp project from 0.11 to 0.12,
 
 Run `npm run bundle` to build the code and then run the `./dist/index.js` from the parent directory of the Wasp project you want to test it on.
 
-You can additionally set `WASP_MIGRATE_DEV`` env var to tell it to use `wasp-cli` instead of `wasp` bin.
+You can additionally set `WASP_MIGRATE_DEV` env var to tell it to use `wasp-cli` instead of `wasp` bin.
 
 Example (where `websockets-realtime-voting` is a Wasp app inside `wasp/examples/` dir):
 ```

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "NOTE: Changing the version number on the `main` branch will automatically trigger deployment",
     "of the new version of the package on npm!"
   ],
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "bin": {
     "wasp-migrate": "dist/index.js"


### PR DESCRIPTION
Wasp compiler supports Wasp file names other than `main.wasp` so this upgrades the script to find the `*.wasp` file.